### PR TITLE
adjusts the TechWnd update so that the tech list is repopulated…

### DIFF
--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1807,9 +1807,7 @@ void TechTreeWnd::TechListBox::Update() {
 }
 
 void TechTreeWnd::TechListBox::Populate() {
-    // abort of not visible to see results
-    if (!Visible())
-        return;
+    // let it process even if not currently visible, as may happen during turn-start update/reset
 
     DebugLogger() << "Tech List Box Populating";
 
@@ -2087,7 +2085,7 @@ std::set<TechStatus> TechTreeWnd::GetTechStatusesShown() const
 
 void TechTreeWnd::Update() {
     m_layout_panel->Update();
-    m_tech_list->Update();
+    m_tech_list->Reset();
 }
 
 void TechTreeWnd::Clear() {


### PR DESCRIPTION
…according to the current completed/available/etc. status.  Fixes #1515

Currently, at turn start the TechWnd update causes the panel layout to update the shown techs based.

The simple change in this PR does have the minor drawback that changing a planet focus would now cause the the current vertical scroll status of the tech list to be lost, which is why I am not putting this PR up on the main repo for now.