### PR TITLE
Unrestricted lane travel conform comments

### DIFF
--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -662,7 +662,7 @@ private:
     // cached calculation results, returned by reference
     std::map<int, float>            m_supply_system_ranges;         ///< number of starlane jumps away from each system (by id) supply can be conveyed.  This is the number due to a system's contents conveying supply and is computed and set by UpdateSystemSupplyRanges
     std::set<int>                   m_supply_unobstructed_systems;  ///< ids of system that don't block supply from flowing
-    std::map<int, std::set<int>>    m_available_system_exit_lanes;  ///< for each system known to this empire, the set of available/non-blockaded exit lanes for fleet travel
+    std::map<int, std::set<int>>    m_available_system_exit_lanes;  ///< for each system known to this empire, the set of exit lanes preserved for fleet travel even if otherwise blockaded
     std::map<int, std::set<int>>    m_pending_system_exit_lanes;    ///< pending updates to m_available_system_exit_lanes
 
     friend class boost::serialization::access;

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -368,8 +368,9 @@ public:
       * exchange supply between themselves (even if not leaving the system). */
     const std::set<int>&                    SupplyUnobstructedSystems() const;
 
-    /** Returns true if the start system is known to this empire and travel to
-        the dest system is not restricted by blockade.  */
+    /** Returns true if the specified lane travel is preserved against being blockaded (i.e., the empire
+     * has in the start system at least one fleet that meets the requirements to preserve the lane (which
+     * is determined in Empire::UpdateSupplyUnobstructedSystems(). */
     const bool                              UnrestrictedLaneTravel(int start_system_id, int dest_system_id) const;
 
     const std::set<int>&                    ExploredSystems() const;    ///< returns set of ids of systems that this empire has explored


### PR DESCRIPTION
As noted in Issue Ref, there is currently a mismatch between the description and actual operation of  ```UnrestrictedLaneTravel()```; this PR proposes to correct that by correcting the comments/description to conform to the actual operation.  

(This is presented along with the main alternative correction for consideration in Ref, which instead proposes to conform the operation to the current description, which essentially causes it to merge in the results from ```Empire::SupplyUnobstructedSystems()```.)

As noted in the above Issue, for the main code base either approach would not make a current difference in operation, because of the manner in which all current uses of ```UnrestrictedLaneTravel()``` are also accompanied (directly or indirectly) by references to ```Empire::SupplyUnobstructedSystems```.

However, the AI could beneficially use the more specific information as retained in this PR (and that information could be separately recreated if necessary, but that would seem cluttered and wasteful).

A further clarification that might be helpful as part of this PR could be to change the attribute and method names to be ```m_preserved_system_exit_lanes``` and ```PreservedLaneTravel()```
